### PR TITLE
Docker: use scratch instead of alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
-FROM alpine
-COPY target/x86_64-unknown-linux-musl/release/richard /usr/local/bin/richard
-CMD /usr/local/bin/richard
+FROM scratch
+COPY target/x86_64-unknown-linux-musl/release/richard /
+WORKDIR /
+ENTRYPOINT ["/richard"]


### PR DESCRIPTION
Maybe I missed something but the alpine image doesn’t seem necessary.